### PR TITLE
fix: correct typo in link_dotfiles.sh backup filename

### DIFF
--- a/link_dotfiles.sh
+++ b/link_dotfiles.sh
@@ -14,7 +14,7 @@ for target in ${targets}; do
   else
     if [ -f ${target_home} ]; then
         echo "rename current file: ${target_home}"
-      mv -i ${target_home} ${target_home}.pre-manage-dotflies
+      mv -i ${target_home} ${target_home}.pre-manage-dotfiles
     fi
 
     if [ -d ${target_home} ]; then


### PR DESCRIPTION
## Summary
• Fixed typo in link_dotfiles.sh where backup filename was "pre-manage-dotflies" instead of "pre-manage-dotfiles"
• Ensures consistent naming convention for backup files

## Test plan
- [x] Verify the typo has been corrected in line 17
- [x] Test the script to ensure backup functionality works correctly
- [x] Confirm no other similar typos exist in the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)