### PR TITLE
feat: add security-sensitive config files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .claude/projects/
 .claude/statsig/
 .claude/todos/
+
+# Security-sensitive configuration files
+.config/gh/hosts.yml


### PR DESCRIPTION
## Summary
• Added `.config/gh/hosts.yml` to gitignore to prevent committing security-sensitive GitHub CLI configuration

## Test plan
- [x] Verify .gitignore syntax is correct
- [x] Confirm sensitive config files are properly excluded from version control

🤖 Generated with [Claude Code](https://claude.ai/code)