### PR TITLE
feat: add zsh plugins and update documentation

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -87,7 +87,11 @@ HIST_STAMPS="mm/dd/yyyy"
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
-plugins=(git)
+plugins=(
+  git
+  zsh-autosuggestions
+  zsh-syntax-highlighting
+)
 
 source $ZSH/oh-my-zsh.sh
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ dofile置き場
 ## Requirements and dependencies
 
 - [Zsh](https://www.zsh.org/)
+
 - [Oh My Zsh](https://github.com/ohmyzsh/ohmyzsh)
+  - [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting)
+  - [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions)
 
 - [lazygit](https://github.com/jesseduffield/lazygit)

--- a/docs/install-oh-my-zsh.md
+++ b/docs/install-oh-my-zsh.md
@@ -7,3 +7,20 @@ $ sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/t
 # .zshrcが上書きされるので、シンボリックリンクを張りなおす
 $ ./link_dotfiles.s
 ```
+
+## プラグインのインストール
+
+zsh-autosuggestions
+
+```bash
+git clone https://github.com/zsh-users/zsh-autosuggestions \
+  ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
+```
+
+zsh-syntax-highlighting
+
+```bash
+git clone https://github.com/zsh-users/zsh-syntax-highlighting.git \
+  ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
+```
+


### PR DESCRIPTION
## Summary
- Add zsh-autosuggestions and zsh-syntax-highlighting plugins to .zshrc configuration
- Update README.md to include plugin dependencies in requirements section
- Add detailed plugin installation instructions to Oh My Zsh guide

## Test plan
- [x] Verify .zshrc loads plugins correctly after Oh My Zsh installation
- [x] Confirm plugin installation commands work as documented
- [x] Test that autosuggestions and syntax highlighting function properly